### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ This addon just provides the basics to run backstopjs and some basic tests, but 
 
 ## Getting started
 
-Install this addon with
+Install this addon
+
+For DDEV v1.23.5 or above run
+
+```shell
+ddev add-on get Metadrop/ddev-backstopjs
+```
+
+For earlier versions of DDEV run
 
 ```shell
 ddev get Metadrop/ddev-backstopjs


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.