### PR TITLE
Use metadrop/aljibe-tools base image and pull from ghcr.io

### DIFF
--- a/backstopjsBuild/Dockerfile
+++ b/backstopjsBuild/Dockerfile
@@ -2,21 +2,32 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
+# Install sudo.
+USER root
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+    sudo \
+  ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
+
+# Configure sudo in a manner similar to other ddev containers.
+RUN mkdir /etc/sudoers.d; echo "ALL ALL=NOPASSWD: ALL" > /etc/sudoers.d/ddev-backstop && chmod 440 /etc/sudoers.d/ddev-backstop
+
+# Add current ddev user.
+ARG username
+ARG uid
+ARG gid
+RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || useradd  -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username" || useradd -l -m -s "/bin/bash" --comment '' $username )
+
 # Add custom entrypoint
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# delete the default 'node' user with uid 1000 and add current ddev user
-ARG username
-ARG uid
-ARG gid
-RUN userdel -r node
-RUN (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' --uid $uid "$username" || useradd  -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || useradd  -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username" || useradd -l -m -s "/bin/bash" --comment '' $username )
-
-# Add sudo and sudoers in manner similar to other ddev containers
-RUN apt update && apt install -y sudo; apt clean -qq && rm -rf /var/lib/apt/lists/*; echo "ALL ALL=NOPASSWD: ALL" > /etc/sudoers.d/ddev-backstop && chmod 440 /etc/sudoers.d/ddev-backstop
-
-# Install mkcert
-RUN apt update --fix-missing; apt install -y curl libnss3-tools; curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"; chmod +x mkcert-v*-linux-amd64; cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+# Install mkcert.
+RUN curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" \
+  && chmod +x mkcert-v*-linux-amd64 \
+  && mv mkcert-v*-linux-amd64 /usr/local/bin/mkcert
 
 USER $username

--- a/docker-compose.backstopjs.yaml
+++ b/docker-compose.backstopjs.yaml
@@ -5,11 +5,11 @@ services:
     build:
       context: './backstopjsBuild'
       args:
-        BASE_IMAGE: backstopjs/backstopjs:${BACKSTOPJS_VERSION:-6.3.3}
+        BASE_IMAGE: ghcr.io/metadrop/aljibe-tools/backstopjs:${BACKSTOPJS_VERSION:-6.3.7}
         username: $USER
         uid: $DDEV_UID
         gid: $DDEV_GID
-    image: backstopjs/backstopjs:${BACKSTOPJS_VERSION:-6.3.3}-${DDEV_SITENAME}-built
+    image: ghcr.io/metadrop/aljibe-tools/backstopjs:${BACKSTOPJS_VERSION:-6.3.7}-${DDEV_SITENAME}-built
     user:  '$DDEV_UID:$DDEV_GID'
     restart: "no"
     # Add init to reap Chrome processes, as noted at


### PR DESCRIPTION
  - Pull from ghcr.io to overcome upcoming dockerhub limitations
  - metadrop/aljibe-tools is smaller (1.26GB vs 3.7GB)
  - Adapt ddev customizations Dockerfile to work with new image